### PR TITLE
Improve atomic execution protocol

### DIFF
--- a/actors/hierarchical_sca/src/checkpoint.rs
+++ b/actors/hierarchical_sca/src/checkpoint.rs
@@ -1,3 +1,5 @@
+use actor_primitives::tcid::TCid;
+use actor_primitives::tcid::TLink;
 use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
@@ -9,8 +11,7 @@ use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 
-use crate::tcid::{TCid, TLink};
-use crate::CrossMsgs;
+use crate::cross::CrossMsgs;
 
 #[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 pub struct Checkpoint {

--- a/actors/hierarchical_sca/src/cross.rs
+++ b/actors/hierarchical_sca/src/cross.rs
@@ -1,124 +1,14 @@
-use anyhow::anyhow;
+use actor_primitives::tcid::TAmt;
+use actor_primitives::tcid::TCid;
+use actor_primitives::tcid::TLink;
+use actor_primitives::types::StorableMsg;
 use cid::Cid;
-use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
 use fvm_ipld_blockstore::Blockstore;
 use fvm_ipld_blockstore::MemoryBlockstore;
 use fvm_ipld_encoding::tuple::*;
 use fvm_ipld_encoding::Cbor;
-use fvm_ipld_encoding::RawBytes;
-use fvm_shared::address::{Address, SubnetID};
-use fvm_shared::bigint::bigint_ser;
-use fvm_shared::econ::TokenAmount;
-use fvm_shared::MethodNum;
-use fvm_shared::METHOD_SEND;
-use std::path::Path;
 
 use crate::checkpoint::CrossMsgMeta;
-use crate::tcid::{TAmt, TCid, TLink};
-
-/// StorableMsg stores all the relevant information required
-/// to execute cross-messages.
-///
-/// We follow this approach because we can't directly store types.Message
-/// as we did in the actor's Go counter-part. Instead we just persist the
-/// information required to create the cross-messages and execute in the
-/// corresponding node implementation.
-#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct StorableMsg {
-    pub from: Address,
-    pub to: Address,
-    pub method: MethodNum,
-    pub params: RawBytes,
-    #[serde(with = "bigint_ser")]
-    pub value: TokenAmount,
-    pub nonce: u64,
-}
-impl Cbor for StorableMsg {}
-
-impl Default for StorableMsg {
-    fn default() -> Self {
-        Self {
-            from: Address::new_id(0),
-            to: Address::new_id(0),
-            method: 0,
-            params: RawBytes::default(),
-            value: TokenAmount::from(0),
-            nonce: 0,
-        }
-    }
-}
-
-#[derive(PartialEq, Eq)]
-pub enum HCMsgType {
-    Unknown = 0,
-    BottomUp,
-    TopDown,
-}
-
-impl StorableMsg {
-    pub fn new_release_msg(
-        sub_id: &SubnetID,
-        sig_addr: &Address,
-        value: TokenAmount,
-        nonce: u64,
-    ) -> anyhow::Result<Self> {
-        let to = Address::new_hierarchical(
-            &match sub_id.parent() {
-                Some(s) => s,
-                None => return Err(anyhow!("error getting parent for subnet addr")),
-            },
-            sig_addr,
-        )?;
-        let from = Address::new_hierarchical(sub_id, &BURNT_FUNDS_ACTOR_ADDR)?;
-        Ok(Self { from, to, method: METHOD_SEND, params: RawBytes::default(), value, nonce })
-    }
-
-    pub fn new_fund_msg(
-        sub_id: &SubnetID,
-        sig_addr: &Address,
-        value: TokenAmount,
-    ) -> anyhow::Result<Self> {
-        let from = Address::new_hierarchical(
-            &match sub_id.parent() {
-                Some(s) => s,
-                None => return Err(anyhow!("error getting parent for subnet addr")),
-            },
-            sig_addr,
-        )?;
-        let to = Address::new_hierarchical(sub_id, sig_addr)?;
-        // the nonce and the rest of message fields are set when the message is committed.
-        Ok(Self { from, to, method: METHOD_SEND, value, ..Default::default() })
-    }
-
-    pub fn hc_type(&self) -> anyhow::Result<HCMsgType> {
-        let sto = self.to.subnet()?;
-        let sfrom = self.from.subnet()?;
-        if is_bottomup(&sfrom, &sto) {
-            return Ok(HCMsgType::BottomUp);
-        }
-        Ok(HCMsgType::TopDown)
-    }
-
-    pub fn apply_type(&self, curr: &SubnetID) -> anyhow::Result<HCMsgType> {
-        let sto = self.to.subnet()?;
-        let sfrom = self.from.subnet()?;
-        if curr.common_parent(&sto) == sfrom.common_parent(&sto)
-            && self.hc_type()? == HCMsgType::BottomUp
-        {
-            return Ok(HCMsgType::BottomUp);
-        }
-        Ok(HCMsgType::TopDown)
-    }
-}
-
-pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
-    let index = match from.common_parent(&to) {
-        Some((ind, _)) => ind,
-        None => return false,
-    };
-    let a = from.to_string();
-    Path::new(&a).components().count() - 1 > index
-}
 
 #[derive(PartialEq, Eq, Clone, Debug, Default, Serialize_tuple, Deserialize_tuple)]
 pub struct CrossMsgs {
@@ -177,27 +67,5 @@ impl CrossMsgs {
         // TODO: Check if the message has already been added.
         self.msgs.push(msg.clone());
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::cross::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn test_is_bottomup() {
-        bottom_up("/root/f01", "/root/f01/f02", false);
-        bottom_up("/root/f01", "/root", true);
-        bottom_up("/root/f01", "/root/f01/f02", false);
-        bottom_up("/root/f01", "/root/f02/f02", true);
-        bottom_up("/root/f01/f02", "/root/f01/f02", false);
-        bottom_up("/root/f01/f02", "/root/f01/f02/f03", false);
-    }
-    fn bottom_up(a: &str, b: &str, res: bool) {
-        assert_eq!(
-            is_bottomup(&SubnetID::from_str(a).unwrap(), &SubnetID::from_str(b).unwrap()),
-            res
-        );
     }
 }

--- a/actors/hierarchical_sca/src/state.rs
+++ b/actors/hierarchical_sca/src/state.rs
@@ -628,8 +628,10 @@ impl State {
                 // common checks
                 atomic_exec_checks(&exec, &cid, &caller)?;
 
+                // TODO:
                 // check that that the input state has been correctly
                 // linked to the execution.
+                panic!("Linked Cid check not implemented yet");
 
                 // check if all the submitted are equal to current cid
                 let out_cids: Vec<Cid> = exec.submitted().values().cloned().collect();

--- a/actors/hierarchical_sca/src/subnet.rs
+++ b/actors/hierarchical_sca/src/subnet.rs
@@ -1,3 +1,6 @@
+use actor_primitives::tcid::TAmt;
+use actor_primitives::tcid::TCid;
+use actor_primitives::types::StorableMsg;
 use anyhow::anyhow;
 use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_blockstore::Blockstore;
@@ -8,11 +11,9 @@ use fvm_shared::address::SubnetID;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::econ::TokenAmount;
 
-use crate::tcid::{TAmt, TCid};
 use crate::CROSSMSG_AMT_BITWIDTH;
 
 use super::checkpoint::*;
-use super::cross::StorableMsg;
 use super::state::State;
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Serialize_repr)]

--- a/actors/hierarchical_sca/src/types.rs
+++ b/actors/hierarchical_sca/src/types.rs
@@ -1,5 +1,5 @@
 use fil_actors_runtime::Array;
-use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::{tuple::*, RawBytes};
 use fvm_shared::address::SubnetID;
 use fvm_shared::bigint::bigint_ser;
 use fvm_shared::clock::ChainEpoch;
@@ -37,4 +37,11 @@ pub struct CheckpointParams {
 pub struct CrossMsgParams {
     pub msg: StorableMsg,
     pub destination: SubnetID,
+}
+
+/// Wrapper for the output of the result for the application of a
+/// cross-message validation
+#[derive(Serialize_tuple, Deserialize_tuple, Clone)]
+pub struct ApplyMsgOutput {
+    pub output: RawBytes,
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod atomic;
 pub mod taddress;
 pub mod tcid;
+pub mod types;

--- a/primitives/src/types.rs
+++ b/primitives/src/types.rs
@@ -1,0 +1,117 @@
+use std::path::Path;
+
+use anyhow::anyhow;
+use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::Cbor;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::{Address, SubnetID};
+use fvm_shared::bigint::bigint_ser;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::MethodNum;
+use fvm_shared::METHOD_SEND;
+
+/// StorableMsg stores all the relevant information required
+/// to execute cross-messages.
+///
+/// We follow this approach because we can't directly store types.Message
+/// as we did in the actor's Go counter-part. Instead we just persist the
+/// information required to create the cross-messages and execute in the
+/// corresponding node implementation.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct StorableMsg {
+    pub from: Address,
+    pub to: Address,
+    pub method: MethodNum,
+    pub params: RawBytes,
+    #[serde(with = "bigint_ser")]
+    pub value: TokenAmount,
+    pub nonce: u64,
+}
+impl Cbor for StorableMsg {}
+
+impl Default for StorableMsg {
+    fn default() -> Self {
+        Self {
+            from: Address::new_id(0),
+            to: Address::new_id(0),
+            method: 0,
+            params: RawBytes::default(),
+            value: TokenAmount::from(0),
+            nonce: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum HCMsgType {
+    Unknown = 0,
+    BottomUp,
+    TopDown,
+}
+
+impl StorableMsg {
+    pub fn new_release_msg(
+        sub_id: &SubnetID,
+        sig_addr: &Address,
+        value: TokenAmount,
+        nonce: u64,
+    ) -> anyhow::Result<Self> {
+        let to = Address::new_hierarchical(
+            &match sub_id.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            sig_addr,
+        )?;
+        let from = Address::new_hierarchical(sub_id, &BURNT_FUNDS_ACTOR_ADDR)?;
+        Ok(Self { from, to, method: METHOD_SEND, params: RawBytes::default(), value, nonce })
+    }
+
+    pub fn new_fund_msg(
+        sub_id: &SubnetID,
+        sig_addr: &Address,
+        value: TokenAmount,
+    ) -> anyhow::Result<Self> {
+        let from = Address::new_hierarchical(
+            &match sub_id.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            sig_addr,
+        )?;
+        let to = Address::new_hierarchical(sub_id, sig_addr)?;
+        // the nonce and the rest of message fields are set when the message is committed.
+        Ok(Self { from, to, method: METHOD_SEND, value, ..Default::default() })
+    }
+
+    pub fn hc_type(&self) -> anyhow::Result<HCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if is_bottomup(&sfrom, &sto) {
+            return Ok(HCMsgType::BottomUp);
+        }
+        Ok(HCMsgType::TopDown)
+    }
+
+    pub fn apply_type(&self, curr: &SubnetID) -> anyhow::Result<HCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if curr.common_parent(&sto) == sfrom.common_parent(&sto)
+            && self.hc_type()? == HCMsgType::BottomUp
+        {
+            return Ok(HCMsgType::BottomUp);
+        }
+        Ok(HCMsgType::TopDown)
+    }
+}
+
+/// Determines if a cross-message is bottom-up
+pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
+    let index = match from.common_parent(&to) {
+        Some((ind, _)) => ind,
+        None => return false,
+    };
+    let a = from.to_string();
+    Path::new(&a).components().count() - 1 > index
+}

--- a/primitives/types.rs
+++ b/primitives/types.rs
@@ -1,0 +1,140 @@
+use anyhow::anyhow;
+use cid::Cid;
+use fil_actors_runtime::BURNT_FUNDS_ACTOR_ADDR;
+use fvm_ipld_blockstore::Blockstore;
+use fvm_ipld_blockstore::MemoryBlockstore;
+use fvm_ipld_encoding::tuple::*;
+use fvm_ipld_encoding::Cbor;
+use fvm_ipld_encoding::RawBytes;
+use fvm_shared::address::{Address, SubnetID};
+use fvm_shared::bigint::bigint_ser;
+use fvm_shared::econ::TokenAmount;
+use fvm_shared::MethodNum;
+use fvm_shared::METHOD_SEND;
+use std::path::Path;
+
+/// StorableMsg stores all the relevant information required
+/// to execute cross-messages.
+///
+/// We follow this approach because we can't directly store types.Message
+/// as we did in the actor's Go counter-part. Instead we just persist the
+/// information required to create the cross-messages and execute in the
+/// corresponding node implementation.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+pub struct StorableMsg {
+    pub from: Address,
+    pub to: Address,
+    pub method: MethodNum,
+    pub params: RawBytes,
+    #[serde(with = "bigint_ser")]
+    pub value: TokenAmount,
+    pub nonce: u64,
+}
+impl Cbor for StorableMsg {}
+
+impl Default for StorableMsg {
+    fn default() -> Self {
+        Self {
+            from: Address::new_id(0),
+            to: Address::new_id(0),
+            method: 0,
+            params: RawBytes::default(),
+            value: TokenAmount::from(0),
+            nonce: 0,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum HCMsgType {
+    Unknown = 0,
+    BottomUp,
+    TopDown,
+}
+
+impl StorableMsg {
+    pub fn new_release_msg(
+        sub_id: &SubnetID,
+        sig_addr: &Address,
+        value: TokenAmount,
+        nonce: u64,
+    ) -> anyhow::Result<Self> {
+        let to = Address::new_hierarchical(
+            &match sub_id.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            sig_addr,
+        )?;
+        let from = Address::new_hierarchical(sub_id, &BURNT_FUNDS_ACTOR_ADDR)?;
+        Ok(Self { from, to, method: METHOD_SEND, params: RawBytes::default(), value, nonce })
+    }
+
+    pub fn new_fund_msg(
+        sub_id: &SubnetID,
+        sig_addr: &Address,
+        value: TokenAmount,
+    ) -> anyhow::Result<Self> {
+        let from = Address::new_hierarchical(
+            &match sub_id.parent() {
+                Some(s) => s,
+                None => return Err(anyhow!("error getting parent for subnet addr")),
+            },
+            sig_addr,
+        )?;
+        let to = Address::new_hierarchical(sub_id, sig_addr)?;
+        // the nonce and the rest of message fields are set when the message is committed.
+        Ok(Self { from, to, method: METHOD_SEND, value, ..Default::default() })
+    }
+
+    pub fn hc_type(&self) -> anyhow::Result<HCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if is_bottomup(&sfrom, &sto) {
+            return Ok(HCMsgType::BottomUp);
+        }
+        Ok(HCMsgType::TopDown)
+    }
+
+    pub fn apply_type(&self, curr: &SubnetID) -> anyhow::Result<HCMsgType> {
+        let sto = self.to.subnet()?;
+        let sfrom = self.from.subnet()?;
+        if curr.common_parent(&sto) == sfrom.common_parent(&sto)
+            && self.hc_type()? == HCMsgType::BottomUp
+        {
+            return Ok(HCMsgType::BottomUp);
+        }
+        Ok(HCMsgType::TopDown)
+    }
+}
+
+pub fn is_bottomup(from: &SubnetID, to: &SubnetID) -> bool {
+    let index = match from.common_parent(&to) {
+        Some((ind, _)) => ind,
+        None => return false,
+    };
+    let a = from.to_string();
+    Path::new(&a).components().count() - 1 > index
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::cross::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_is_bottomup() {
+        bottom_up("/root/f01", "/root/f01/f02", false);
+        bottom_up("/root/f01", "/root", true);
+        bottom_up("/root/f01", "/root/f01/f02", false);
+        bottom_up("/root/f01", "/root/f02/f02", true);
+        bottom_up("/root/f01/f02", "/root/f01/f02", false);
+        bottom_up("/root/f01/f02", "/root/f01/f02/f03", false);
+    }
+    fn bottom_up(a: &str, b: &str, res: bool) {
+        assert_eq!(
+            is_bottomup(&SubnetID::from_str(a).unwrap(), &SubnetID::from_str(b).unwrap()),
+            res
+        );
+    }
+}


### PR DESCRIPTION
The goal of this PR is to implement the new design for the atomic execution protocol discussed here: https://github.com/protocol/ConsensusLab/discussions/154.

- [ ] It modifies the primitives and interactions of the actors support atomic executions and the SCA of the common parent orchestrating it.
- [ ] It introduces the submission of the output for the atomic execution as a top-down message triggered by the `pre_commit` function in the source actor.
- [ ] It introduces a set of refactors and improvements in the code structure.

_Note: The unit tests do not pass yet, I will need to introduce the corresponding changes when I'm back_